### PR TITLE
Fix outside landmines spawning in the air

### DIFF
--- a/SuperLandmine/Patchs/SuperLandminePatch.cs
+++ b/SuperLandmine/Patchs/SuperLandminePatch.cs
@@ -201,6 +201,12 @@ namespace SuperLandmine.Patchs
         {
             if (Plugin.config_LandmineCanSpawnOutside.Value == true && __instance.IsServer && __instance.IsHost)
             {
+                // Delete all existing landmines
+                Utils.OutsideLandmineMarker[] outsideLandmines = GameObject.FindObjectsOfType<Utils.OutsideLandmineMarker>();
+                foreach (Utils.OutsideLandmineMarker landmineMarker in outsideLandmines) {
+                    GameObject.Destroy(landmineMarker.gameObject);
+                }
+
                 Plugin.log.LogInfo("Load landmine");
                 SelectableLevel selectableLevel = __instance.currentLevel;
                 SpawnableMapObject[] spawnableMapObjects = selectableLevel.spawnableMapObjects;
@@ -230,6 +236,8 @@ namespace SuperLandmine.Patchs
                                     GameObject gameObject = UnityEngine.Object.Instantiate<GameObject>(spawnObject.prefabToSpawn, randomNavMeshPositionInBoxPredictable, rotation);
                                     gameObject.SetActive(value: true);
                                     gameObject.GetComponent<NetworkObject>().Spawn();
+                                    // Mark this as an outside landmine
+                                    gameObject.AddComponent<Utils.OutsideLandmineMarker>();
                                 }
                             }
 

--- a/SuperLandmine/Patchs/SuperLandminePatch.cs
+++ b/SuperLandmine/Patchs/SuperLandminePatch.cs
@@ -224,8 +224,10 @@ namespace SuperLandmine.Patchs
                                 {
                                     System.Random random = new System.Random();
                                     Vector3 randomNavMeshPositionInBoxPredictable = __instance.GetRandomNavMeshPositionInBoxPredictable(shipSpawnPathPoints[i].position, 300f, __instance.navHit, random, -5);
+                                    Quaternion rotation;
+                                    (randomNavMeshPositionInBoxPredictable, rotation) = Utils.projectToGround(randomNavMeshPositionInBoxPredictable);
                                     Plugin.log.LogInfo("Spawn landmine outside at" + randomNavMeshPositionInBoxPredictable.ToString());
-                                    GameObject gameObject = UnityEngine.Object.Instantiate<GameObject>(spawnObject.prefabToSpawn, randomNavMeshPositionInBoxPredictable, Quaternion.identity);
+                                    GameObject gameObject = UnityEngine.Object.Instantiate<GameObject>(spawnObject.prefabToSpawn, randomNavMeshPositionInBoxPredictable, rotation);
                                     gameObject.SetActive(value: true);
                                     gameObject.GetComponent<NetworkObject>().Spawn();
                                 }

--- a/SuperLandmine/SuperLandmineUtils.cs
+++ b/SuperLandmine/SuperLandmineUtils.cs
@@ -1,11 +1,4 @@
-﻿using System.Collections;
-using BepInEx;
-using GameNetcodeStuff;
-using HarmonyLib;
-using Unity.Netcode;
-using UnityEngine;
-using UnityEngine.AI;
-using UnityEngine.Networking;
+﻿using UnityEngine;
 
 namespace SuperLandmine {
     public static class Utils {

--- a/SuperLandmine/SuperLandmineUtils.cs
+++ b/SuperLandmine/SuperLandmineUtils.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections;
+using BepInEx;
+using GameNetcodeStuff;
+using HarmonyLib;
+using Unity.Netcode;
+using UnityEngine;
+using UnityEngine.AI;
+using UnityEngine.Networking;
+
+namespace SuperLandmine {
+    public static class Utils {
+        public const float MAX_RAYCAST_DIST = 1000f;
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="position"></param>
+        /// <returns>A tuple containing the new position and quaternion when projected to the ground</returns>
+        public static (Vector3, Quaternion) projectToGround(Vector3 position) {
+            Ray ray = new Ray(position, Vector3.down);
+            Quaternion quaternion = Quaternion.identity;
+            Vector3 pos = position;
+            RaycastHit hit;
+            if (Physics.Raycast(ray, out hit, MAX_RAYCAST_DIST)) {
+                pos = hit.point;
+                quaternion = Quaternion.FromToRotation(Vector3.up, hit.normal);
+            }
+            return (pos, quaternion);
+        }
+    }
+}

--- a/SuperLandmine/SuperLandmineUtils.cs
+++ b/SuperLandmine/SuperLandmineUtils.cs
@@ -2,7 +2,7 @@
 
 namespace SuperLandmine {
     public static class Utils {
-        public const float MAX_RAYCAST_DIST = 10000f;
+        public const float MAX_RAYCAST_DIST = 30000f;
         /// <summary>
         /// 
         /// </summary>
@@ -19,5 +19,10 @@ namespace SuperLandmine {
             }
             return (pos, quaternion);
         }
+
+        /// <summary>
+        /// A marker class to identify outside landmines
+        /// </summary>
+        public class OutsideLandmineMarker : MonoBehaviour { }
     }
 }

--- a/SuperLandmine/SuperLandmineUtils.cs
+++ b/SuperLandmine/SuperLandmineUtils.cs
@@ -2,7 +2,7 @@
 
 namespace SuperLandmine {
     public static class Utils {
-        public const float MAX_RAYCAST_DIST = 1000f;
+        public const float MAX_RAYCAST_DIST = 10000f;
         /// <summary>
         /// 
         /// </summary>


### PR DESCRIPTION
This PR fixes outside landmines spawning in the air, it also sets their rotation to align with the ground.

This is achieved by casting a ray downwards and finding the hit position and normal.

Also, there was an issue where previously spawned in landmines wouldn't get cleaned up when changing maps. We now mark landmines with an `OutsideLandmine` marker component which allows us to easily clean them up on the next round, before spawning new ones.